### PR TITLE
Update SUMMARY.md

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -49,16 +49,6 @@
   - [Useful Twilio Links](campaign-guide/sms/useful-twilio-links.md)
   - [Postman's SMS API](campaign-guide/sms/postmans-sms-api.md)
 
-## Campaign Guide - Telegram
-
-- [🤖 Telegram Campaigns - Basics](campaign-guide/quick-start/telegram-bot/README.md)
-  - [How do I set up Telegram to send my campaigns?](campaign-guide/telegram-bot/how-do-i-set-up-telegram-to-send-my-campaigns.md)
-  - [Add Telegram Bot Token in Postman](campaign-guide/quick-start/telegram-bot/add-telegram-bot-token-in-postman.md)
-  - [Instructions for Recipient Onboarding](campaign-guide/quick-start/telegram-bot/instructions-recipient-telegram.md)
-  - [Use the Bot in the Campaign](campaign-guide/quick-start/telegram-bot/use-the-bot-in-the-campaign.md)
-  - [Telegram Formatting](campaign-guide/quick-start/telegram-bot/telegram-formatting.md)
-  - [Telegram Bot Statistics](campaign-guide/quick-start/telegram-bot/telegram-bot-statistics.md)
-
 ## Campaign Guide - Gov.sg WhatsApp
 
 - [📞 The official Gov.sg WhatsApp channel](campaign-guide-gov.sg-whatsapp/the-official-gov.sg-whatsapp-channel.md)


### PR DESCRIPTION
## Problem

The gitbook guide contains information about using telegram campaigns. As we are removing this feature, we no longer want to present this information in our official guides. 

## Solution
Removed following lines from summary to hide pages. Pages are **_not_** deleted from gitbook but hidden

- [🤖 Telegram Campaigns - Basics](campaign-guide/quick-start/telegram-bot/README.md)
  - [How do I set up Telegram to send my campaigns?](campaign-guide/telegram-bot/how-do-i-set-up-telegram-to-send-my-campaigns.md)
  - [Add Telegram Bot Token in Postman](campaign-guide/quick-start/telegram-bot/add-telegram-bot-token-in-postman.md)
  - [Instructions for Recipient Onboarding](campaign-guide/quick-start/telegram-bot/instructions-recipient-telegram.md)
  - [Use the Bot in the Campaign](campaign-guide/quick-start/telegram-bot/use-the-bot-in-the-campaign.md)
  - [Telegram Formatting](campaign-guide/quick-start/telegram-bot/telegram-formatting.md)
  - [Telegram Bot Statistics](campaign-guide/quick-start/telegram-bot/telegram-bot-statistics.md)